### PR TITLE
Compare proposals functionality disabled

### DIFF
--- a/config/initializers/proposals.rb
+++ b/config/initializers/proposals.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Decidim::Proposals.configure do |config|
+  config.similarity_threshold = 0.99
+  config.similarity_limit = 2
+end


### PR DESCRIPTION
Initializer for proposal's gem configuration, added in order to alter the compare functionality and not to be restrictive.