### PR TITLE
Enable video upload on proposals for all the users

### DIFF
--- a/app/helpers/decidim/proposals/application_helper_override.rb
+++ b/app/helpers/decidim/proposals/application_helper_override.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   module Proposals
     module ApplicationHelperOverride

--- a/app/helpers/decidim/proposals/application_helper_override.rb
+++ b/app/helpers/decidim/proposals/application_helper_override.rb
@@ -1,0 +1,13 @@
+module Decidim
+  module Proposals
+    module ApplicationHelperOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def safe_content_admin?
+          true
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Decidim::Proposals::ApplicationHelper.include(Decidim::Proposals::ApplicationHelperOverride)
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -11,6 +11,12 @@ checksums = [
     files: {
       "/lib/decidim/amendable.rb" => "7c6d8a85102bf1a8c3376ef47422b5df"
     }
+  },
+  {
+    package: "decidim-proposals",
+    files: {
+      "/app/helpers/decidim/proposals/application_helper.rb" => "a9c9ed5eedaf7bf80afaf9ff5a89c254"
+    }
   }
 ]
 


### PR DESCRIPTION
#### :tophat: What? Why?

Mark all the proposal content as created by an admin to enable iframes when a regular user creates a new proposal.

#### :pushpin: Related Issues

- Fixes #26 

### :camera: Screenshots

<img width="1292" alt="Screenshot 2023-11-08 at 14 32 59" src="https://github.com/Platoniq/decidim-euteens4green/assets/6973564/9b107498-08fb-47bd-bf8a-a281d3dd3d16">
