### PR TITLE
Disable vote proposal for proposal authors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,21 +52,12 @@ Capfile
 
 .rubocop*
 
-node_modules
 /public/decidim-packs
 /public/packs
 /public/packs-test
-/node_modules
-/yarn-error.log
-yarn-debug.log*
-.yarn-integrity
-/public/packs
-/public/packs-test
-/node_modules
-/yarn-error.log
 yarn-debug.log*
 .yarn-integrity
 
 
-public/sw.js
-public/sw.js.map
+public/sw.js*
+public/sw.js.map*

--- a/app/permissions/concerns/decidim/proposals/permissions_override.rb
+++ b/app/permissions/concerns/decidim/proposals/permissions_override.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module PermissionsOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def can_vote_proposal?
+          is_allowed = proposal &&
+                       !proposal.authored_by?(user) &&
+                       authorized?(:vote, resource: proposal) &&
+                       voting_enabled? &&
+                       remaining_votes.positive?
+
+          toggle_allow(is_allowed)
+        end
+
+        def can_unvote_proposal?
+          is_allowed = proposal &&
+                       !proposal.authored_by?(user) &&
+                       authorized?(:vote, resource: proposal) &&
+                       voting_enabled?
+
+          toggle_allow(is_allowed)
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/proposals/proposals/show.html.erb
+++ b/app/views/decidim/proposals/proposals/show.html.erb
@@ -1,0 +1,143 @@
+<% add_decidim_meta_tags({
+                           description: present(@proposal).body,
+                           title: present(@proposal).title,
+                           url: proposal_url(@proposal.id)
+                         }) %>
+
+<%
+  edit_link(
+    resource_locator(@proposal).edit,
+    :edit,
+    :proposal,
+    proposal: @proposal
+  )
+%>
+
+<%
+  extra_admin_link(
+    resource_locator(@proposal).show(anchor: "proposal-answer"),
+    :create,
+    :proposal_answer,
+    { proposal: @proposal },
+    { name: t(".answer"), icon: "comment-square" }
+  )
+%>
+
+<%= render partial: "voting_rules" %>
+<% if component_settings.participatory_texts_enabled? %>
+  <div class="row column">
+    <div class="section text-medium">
+      <%= t(".back_to") %> <u><%= link_to translated_attribute(@participatory_text.title), main_component_path(current_component) %></u>
+    </div>
+  </div>
+<% end %>
+<%= emendation_announcement_for @proposal %>
+<div class="row column view-header">
+
+  <div class="m-bottom">
+    <%= link_to proposals_path, class: "small hollow js-back-to-list" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back_to_list") %>
+    <% end %>
+  </div>
+
+  <% if @proposal.emendation? %>
+    <h2 class="heading3"><%= t(".changes_at_title", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h2>
+  <% else %>
+    <h2 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
+  <% end %>
+  <% unless component_settings.participatory_texts_enabled? %>
+    <%= cell("decidim/coauthorships", @proposal, has_actions: true, size: 3, context: { current_user: current_user }) %>
+  <% end %>
+</div>
+<div class="row">
+  <div class="columns mediumlarge-8 large-9">
+    <div class="section">
+      <% if @proposal.emendation? %>
+        <%= cell("decidim/diff", proposal_presenter.versions.last) %>
+      <% elsif not ["section","subsection"].include? @proposal.participatory_text_level %>
+        <%== cell("decidim/proposals/proposal_m", @proposal, full_badge: true).badge %>
+        <%= render_proposal_body(@proposal) %>
+      <% end %>
+      <% if component_settings.geocoding_enabled? %>
+        <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
+      <% end %>
+      <% if proposal_has_costs? && current_settings.answers_with_costs? %>
+        <%= cell("decidim/proposals/cost_report", @proposal) %>
+      <% end %>
+      <%= cell "decidim/proposals/proposal_tags", @proposal %>
+    </div>
+
+    <%= cell("decidim/announcement", proposal_reason_callout_announcement, callout_class: proposal_reason_callout_class) if @proposal.answered? && @proposal.published_state? %>
+
+    <%= linked_resources_for @proposal, :results, "included_proposals" %>
+    <%= linked_resources_for @proposal, :projects, "included_proposals" %>
+    <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
+    <%= linked_resources_for @proposal, :proposals, "copied_from_component" %>
+
+    <%= cell "decidim/endorsers_list", @proposal %>
+    <%= amendments_for @proposal %>
+  </div>
+  <div class="columns section view-side mediumlarge-4 large-3">
+    <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
+      <%= link_to t(".edit_proposal"), edit_proposal_path(@proposal), class: "button hollow expanded button--sc" %>
+    <% else %>
+      <%= amend_button_for @proposal %>
+    <% end %>
+
+    <%= emendation_actions_for @proposal %>
+
+    <% if current_settings.votes_enabled? || show_endorsements_card? || current_user %>
+      <% if @proposal.withdrawn? %>
+        <div class="card">
+          <div class="card__content">
+            <% if current_settings.votes_enabled? %>
+              <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <div class="card">
+          <div class="card__content">
+            <% if current_settings.votes_enabled? %>
+              <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+              <% unless @proposal.authored_by?(current_user) %>
+                <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } %>
+              <% end %>
+            <% end %>
+            <div class="row collapse buttons__row">
+              <% if endorsements_enabled? %>
+                <div class="column small-9 collapse">
+                  <%= endorsement_buttons_cell(@proposal) %>
+                </div>
+              <% end %>
+              <div class="column collapse <%= endorsements_enabled? ? "small-3" : "" %>">
+                <%= link_to "#comments", class: "button small compact hollow secondary button--nomargin expanded" do %>
+                  <span class="show-for-sr"><%= present(@proposal).title(html_escape: true) %></span>
+                  <%= icon "comment-square", class: "icon--small", aria_label: t(".comments"), role: "img" %> <%= @proposal.comments_count %>
+                <% end %>
+              </div>
+            </div>
+            <br>
+            <%= follow_button_for(@proposal) %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%= amenders_list_for(@proposal) %>
+
+    <%= resource_reference(@proposal) %>
+    <%= resource_version(proposal_presenter, versions_path: proposal_versions_path(@proposal)) %>
+    <%= cell("decidim/fingerprint", @proposal) %>
+    <%= render partial: "decidim/shared/share_modal", locals: { resource: @proposal } %>
+    <%= embed_modal_for proposal_widget_url(@proposal, format: :js) %>
+    <%= cell "decidim/proposals/proposal_link_to_collaborative_draft", @proposal %>
+    <%= cell "decidim/proposals/proposal_link_to_rejected_emendation", @proposal %>
+  </div>
+</div>
+<%= attachments_for @proposal %>
+
+<%= comments_for @proposal %>
+
+<%= cell("decidim/flag_modal", @proposal) %>

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -2,4 +2,5 @@
 
 Rails.application.config.to_prepare do
   Decidim::Proposals::ApplicationHelper.include(Decidim::Proposals::ApplicationHelperOverride)
+  Decidim::Proposals::Permissions.include(Decidim::Proposals::PermissionsOverride)
 end

--- a/spec/controllers/decidim/proposals/proposal_votes_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposal_votes_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalVotesController, type: :controller do
+      routes { Decidim::Proposals::Engine.routes }
+
+      let(:component) { create(:proposal_component, :with_votes_enabled) }
+      let(:proposal) { create(:proposal, :participant_author, component: component) }
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+
+      let(:params) do
+        {
+          proposal_id: proposal.id,
+          component_id: component.id
+        }
+      end
+
+      before do
+        request.env["decidim.current_organization"] = component.organization
+        request.env["decidim.current_participatory_space"] = component.participatory_space
+        request.env["decidim.current_component"] = component
+        sign_in user
+      end
+
+      shared_context "with proposal author" do
+        let(:user) { proposal.authors.first }
+      end
+
+      describe "POST create" do
+        it "allows voting" do
+          expect { post :create, format: :js, params: params }.to change(ProposalVote, :count).by(1)
+          expect(ProposalVote.last.author).to eq(user)
+          expect(ProposalVote.last.proposal).to eq(proposal)
+        end
+
+        context "when the user is the proposal author" do
+          include_context "with proposal author"
+
+          it "doesn't allow voting" do
+            expect { post :create, format: :js, params: params }.not_to change(ProposalVote, :count)
+          end
+        end
+      end
+
+      describe "DELETE destroy" do
+        before do
+          create(:proposal_vote, proposal: proposal, author: user)
+        end
+
+        it "allows voting" do
+          expect { delete :destroy, format: :js, params: params }.to change(ProposalVote, :count).by(-1)
+          expect(ProposalVote.count).to eq(0)
+        end
+
+        context "when the user is the proposal author" do
+          include_context "with proposal author"
+
+          it "doesn't allow voting" do
+            expect { delete :destroy, format: :js, params: params }.not_to change(ProposalVote, :count)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/proposals/test/factories"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -15,7 +15,9 @@ checksums = [
   {
     package: "decidim-proposals",
     files: {
-      "/app/helpers/decidim/proposals/application_helper.rb" => "a9c9ed5eedaf7bf80afaf9ff5a89c254"
+      "/app/helpers/decidim/proposals/application_helper.rb" => "a9c9ed5eedaf7bf80afaf9ff5a89c254",
+      "/app/permissions/decidim/proposals/permissions.rb" => "676fb50e4984ed3c62ec63cccdfcb051",
+      "/app/views/decidim/proposals/proposals/show.html.erb" => "f27bbec257eb6da28dbdd07ac0a224a5"
     }
   }
 ]

--- a/spec/system/vote_proposal_spec.rb
+++ b/spec/system/vote_proposal_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Support Proposal", type: :system, slow: true do
+  include_context "with a component"
+  let(:manifest_name) { "proposals" }
+
+  let(:component) do
+    create(:proposal_component,
+           :with_votes_enabled,
+           manifest: manifest,
+           participatory_space: participatory_process)
+  end
+  let!(:proposal) { create :proposal, :participant_author, :published, component: component }
+
+  before do
+    login_as user, scope: :user
+    user.confirm
+    visit_component
+    click_link translated(proposal.title)
+  end
+
+  context "when visiting by the author" do
+    let(:user) { proposal.authors.first }
+
+    it "doesn't show the vote proposal button" do
+      expect(page).to have_no_button("Support")
+    end
+  end
+
+  context "when visiting by other user" do
+    let(:user) { create :user, :confirmed, organization: organization }
+
+    it "shows the vote proposal button" do
+      expect(page).to have_button("Support")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Authors are not authorized to vote own proposals. The vote button is hidden for them.

#### :pushpin: Related Issues
 
- Fixes #28 
 
#### Testing

1. Create a proposal component where the participants can create proposals and votes are enabled
2. Create a proposal with your user and go to the proposal page
3. See no vote button is rendered
4. Login with another user
5. See you can vote

### :camera: Screenshots

https://github.com/Platoniq/decidim-euteens4green/assets/6973564/68eae489-3094-4c82-bc7a-ec695239b2ac

:hearts: Thank you!